### PR TITLE
restore php 5.3 compat in HeaderValue. #129

### DIFF
--- a/src/Header/HeaderValue.php
+++ b/src/Header/HeaderValue.php
@@ -87,7 +87,7 @@ final class HeaderValue
                 $lf = ord($value[$i + 1]);
                 $sp = ord($value[$i + 2]);
 
-                if ($lf !== 10 || ! in_array($sp, [9, 32], true)) {
+                if ($lf !== 10 || ! in_array($sp, array(9, 32), true)) {
                     return false;
                 }
 


### PR DESCRIPTION
Error in HeaderValue (version 2.4.11 and 2.4.10) for PHP 5.3.26
